### PR TITLE
ADD script to compare client guessing of blockprint with rocketPool data

### DIFF
--- a/compareResults.py
+++ b/compareResults.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+
+import os
+import pandas as pd
+import numpy as np
+from time import sleep
+import requests
+import json
+from dotenv import load_dotenv
+
+load_dotenv()
+
+API_URL = os.getenv("API_URL")
+
+consensus = {
+    "N": "Nimbus",
+    "P": "Prysm",
+    "L": "Lighthouse",
+    "T": "Teku"
+}
+
+
+def parseGraffiti(f_graffiti):
+    if type(f_graffiti) != str or len(f_graffiti) < 4:
+        return ("Unknown")
+    for client in consensus.values():
+        if client.lower() in f_graffiti.lower():
+            return client
+    if f_graffiti[4] not in consensus:
+        return ("Unknown")
+    return consensus[f_graffiti[4]]
+
+
+def parseClients():
+    df = pd.read_csv("rocket-pool-proposals.csv")[['f_slot', 'f_graffiti']]
+    df['f_client'] = df.apply(
+        lambda row: parseGraffiti(row.f_graffiti), axis=1)
+    df = df.sort_values(by=['f_slot'])
+
+    knownDF = df[df['f_client'] != "Unknown"]
+    knownDF = knownDF[['f_slot', 'f_client']]
+    knownDF = knownDF.reset_index(drop=True)
+
+    knownDF.to_csv("parsedClients.csv")
+    return knownDF
+
+
+def get_validator_proposed_blocks(init_block, end_block):
+    url = f"{API_URL}/{init_block}/{end_block}"
+    response = json.loads(requests.get(url).text)
+    return response
+
+
+def getGuessesBlockprint(rocketDF):
+    bestGuesses = []
+
+    for i in rocketDF.index:
+        block = rocketDF['f_slot'][i]
+        guesses = get_validator_proposed_blocks(block, block + 1)
+        bestGuesses.append(guesses[0]['best_guess_single'])
+    return bestGuesses
+
+
+def main():
+    # add '.head(x)' to the end of the line below to test with a smaller dataset, x being the number of rows
+    rocketDF = parseClients()
+    bestGuesses = getGuessesBlockprint(rocketDF)
+    rocketDF['f_guess'] = bestGuesses
+    rocketDF['match'] = np.where(
+        rocketDF['f_client'] == rocketDF['f_guess'], True, False)
+    rocketDF.to_csv('result.csv')
+
+    matchingPercertage = rocketDF.match.value_counts()[True] / len(rocketDF)
+
+    print('We have a matching percentage of {:.2f}%'.format(
+        matchingPercertage * 100))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
First version of the script to compare client guessing from blockprint with rocketPool data

- Parse RocketPool data graffitis to get the used client 
- Get the guesses from blockprint for the blocks for which we know the client
- Compare the results and print the percentage of matching client we have

I've put a comment in the code (line 66) where you can put '.head()' in order to test with a smaller dataset since it takes quite a lot of time

**/!\\** You will need to create a .env file and put the '**API_URL**' variable, being the url for the blockprint API