### PR TITLE
7 fix bug of guessrequester crashing on certain slot ranges

### DIFF
--- a/guessRequester.py
+++ b/guessRequester.py
@@ -109,6 +109,7 @@ def getSlotGuesses(
     logging.info(
         f"Downloaded {len(block_rewards)} blocks in {round(end_time - start_time, 2)} seconds. Found {end_slot - start_slot - len(block_rewards)+1} missing blocks."
     )
+    
     block_rewards_index = 0
     for i in range(end_slot - start_slot + 1):
         best_guess_multi = ""
@@ -116,7 +117,8 @@ def getSlotGuesses(
         probability_map = "{}"
         proposer_index = None
         slot_num = start_slot + i
-        if len(block_rewards) > 0:
+        # If it managed to download any blocks and if it hasn't reached the end of the downloaded blocks (i.e. there are missing blocks at the end)
+        if len(block_rewards) > 0 and block_rewards_index < len(block_rewards): 
             slot = block_rewards[block_rewards_index]
             if i == int(slot["meta"]["slot"]) - start_slot:
                 block_rewards_index += 1

--- a/load_db.py
+++ b/load_db.py
@@ -61,6 +61,7 @@ def loadSlotGuessesDatabase(
     )
 
     if guesses is not None:
+        start = time.time()
         db.insert_rows(
             "t_slot_client_guesses",
             (
@@ -72,6 +73,8 @@ def loadSlotGuessesDatabase(
             ),
             guesses,
         )
+        end = time.time()
+        logging.info("Inserted {} rows in {} seconds".format(len(guesses), end - start))
 
 
 def backfillSlots(


### PR DESCRIPTION
# Description

Fixed bug of guessrequester crashing on certain slot ranges. If there are missing blocks at the end of the list, it broke. Now it's handled.

Closes #7 